### PR TITLE
Updates 2016 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.7.1
 
 addons:
   apt:
@@ -13,14 +13,20 @@ addons:
       - libclang1-3.9
       - libclang-3.9-dev
 
+env:
+  global:
+    - CC=clang CXX=clang++
+
 install:
   - mkdir -p /home/travis/bin
+  - sudo ln -s /usr/bin/clang-3.9 /home/travis/bin/clang
   - sudo ln -s /usr/bin/llvm-config-3.9 /home/travis/bin/llvm-config
   - sudo ldconfig
 
   - llvm-config --version
   - llvm-config --includedir
   - llvm-config --libdir
+  - clang --version
 
   - make install-dependencies
   - make install-tools
@@ -30,5 +36,4 @@ script:
   - make install
 
   # Test without any coverage
-  - make test-verbose
-
+  - make test-full

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
 install:
   - mkdir -p /home/travis/bin
   - sudo ln -s /usr/bin/llvm-config-3.9 /home/travis/bin/llvm-config
-  - sudo ln -s /usr/lib/llvm-3.9/lib/libclang.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
   - sudo ldconfig
 
   - llvm-config --version

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: all install install-dependencies install-tools test test-verbose
+.PHONY: all install install-dependencies install-tools test test-full test-verbose
 
-ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-export ROOT_DIR
+export ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+export CC := clang
+export CXX := clang++
 
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:) # turn arguments into do-nothing targets
@@ -14,7 +16,10 @@ install:
 install-dependencies:
 	go get -u github.com/stretchr/testify/...
 install-tools:
+
 test:
-	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race ./...
+	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s ./...
+test-full:
+	$(ROOT_DIR)/scripts/test-full.sh
 test-verbose:
-	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race -v ./...
+	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -v ./...

--- a/clang/cgoflags.go
+++ b/clang/cgoflags.go
@@ -1,5 +1,4 @@
 package clang
 
-// #cgo LDFLAGS: -lclang
-// #cgo CFLAGS: -I.
+// #cgo CFLAGS: -I${SRCDIR}
 import "C"

--- a/clang/cgoflags_dynamic.go
+++ b/clang/cgoflags_dynamic.go
@@ -1,0 +1,6 @@
+// +build !static
+
+package clang
+
+// #cgo LDFLAGS: -lclang
+import "C"

--- a/clang/cgoflags_static.go
+++ b/clang/cgoflags_static.go
@@ -1,0 +1,5 @@
+// +build static
+
+package clang
+
+import "C"

--- a/cmd/go-clang-compdb/main.go
+++ b/cmd/go-clang-compdb/main.go
@@ -11,13 +11,17 @@ import (
 )
 
 func main() {
-	if len(os.Args) <= 1 {
+	os.Exit(cmd(os.Args[1:]))
+}
+
+func cmd(args []string) int {
+	if len(args) == 0 {
 		fmt.Printf("**error: you need to give a directory containing a 'compile_commands.json' file\n")
 
-		os.Exit(1)
+		return 1
 	}
 
-	dir := os.ExpandEnv(os.Args[1])
+	dir := os.ExpandEnv(args[0])
 	fmt.Printf(":: inspecting [%s]...\n", dir)
 
 	fname := filepath.Join(dir, "compile_commands.json")
@@ -25,7 +29,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("**error: could not open file [%s]: %v\n", fname, err)
 
-		os.Exit(1)
+		return 1
 	}
 	f.Close()
 
@@ -68,4 +72,6 @@ func main() {
 		}
 	}
 	fmt.Printf(":: inspecting [%s]... [done]\n", dir)
+
+	return 0
 }

--- a/cmd/go-clang-compdb/main_test.go
+++ b/cmd/go-clang-compdb/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoClangCompDB(t *testing.T) {
+	for _, path := range []string{
+		"../../testdata",
+	} {
+		assert.Equal(t, 0, cmd([]string{path}))
+	}
+}

--- a/cmd/go-clang-dump/main.go
+++ b/cmd/go-clang-dump/main.go
@@ -16,8 +16,17 @@ import (
 var fname = flag.String("fname", "", "the file to analyze")
 
 func main() {
+	os.Exit(cmd(os.Args[1:]))
+}
+
+func cmd(args []string) int {
 	fmt.Printf(":: go-clang-dump...\n")
-	flag.Parse()
+	if err := flag.CommandLine.Parse(args); err != nil {
+		fmt.Printf("ERROR: %s", err)
+
+		return 1
+	}
+
 	fmt.Printf(":: fname: %s\n", *fname)
 	fmt.Printf(":: args: %v\n", flag.Args())
 
@@ -25,19 +34,19 @@ func main() {
 		flag.Usage()
 		fmt.Printf("please provide a file name to analyze\n")
 
-		os.Exit(1)
+		return 1
 	}
 
 	idx := clang.NewIndex(0, 1)
 	defer idx.Dispose()
 
-	args := []string{}
+	tuArgs := []string{}
 	if len(flag.Args()) > 0 && flag.Args()[0] == "-" {
-		args = make([]string, len(flag.Args()[1:]))
-		copy(args, flag.Args()[1:])
+		tuArgs = make([]string, len(flag.Args()[1:]))
+		copy(tuArgs, flag.Args()[1:])
 	}
 
-	tu := idx.ParseTranslationUnit(*fname, args, nil, 0)
+	tu := idx.ParseTranslationUnit(*fname, tuArgs, nil, 0)
 	defer tu.Dispose()
 
 	fmt.Printf("tu: %s\n", tu.Spelling())
@@ -76,4 +85,6 @@ func main() {
 	}
 
 	fmt.Printf(":: bye.\n")
+
+	return 0
 }

--- a/cmd/go-clang-dump/main_test.go
+++ b/cmd/go-clang-dump/main_test.go
@@ -1,18 +1,15 @@
-package main_test
+package main
 
 import (
-	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGoClangDump(t *testing.T) {
 	for _, fname := range []string{
 		"../../testdata/basicparsing.c",
 	} {
-		cmd := exec.Command("go-clang-dump", "-fname", fname)
-		err := cmd.Run()
-		if err != nil {
-			t.Fatalf("error running go-clang-dump on %q: %v\n", fname, err)
-		}
+		assert.Equal(t, 0, cmd([]string{"-fname", fname}))
 	}
 }

--- a/scripts/test-full.sh
+++ b/scripts/test-full.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+LLVM_VERSION=$(clang --version | grep --max-count=1 "clang version" | sed -r 's/^.*clang version ([0-9]+\.[0-9]+).+$/\1/')
+
+# Test with the race detector
+CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -v -race ./...
+
+# Test with the address sanitizer
+# TODO there is maybe a problem within clang https://github.com/go-clang/gen/issues/123
+# if [ $(echo "$LLVM_VERSION>=3.9" | bc -l) -ne 0 ] && [ $(find `llvm-config --libdir` | grep libclang_rt.san-x86_64.a | wc -l) -ne 0 ]; then CGO_LDFLAGS="-L`llvm-config --libdir` -fsanitize=memory" CGO_CPPFLAGS='-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer' go test -timeout 60s -v -msan ./...; fi


### PR DESCRIPTION
- Revamp the dump example
- Test compdb example
- Allow static linking
- Get rid of some symbolic links
- Upgrade to Go 1.7